### PR TITLE
content(case-studies): decouple case study previews from project images

### DIFF
--- a/src/content/case-studies/aklish/index.mdx
+++ b/src/content/case-studies/aklish/index.mdx
@@ -2,7 +2,6 @@
 title: "Building a dictionary for a language with none"
 description: "I built Aklish after realizing that looking up Aklanon words often meant asking my parents because there wasn't a reliable online dictionary."
 date: "2024-07-30"
-image: "./preview.png"
 ---
 
 import Callout from "@components/Callout.astro";

--- a/src/content/case-studies/aklstemmer/index.mdx
+++ b/src/content/case-studies/aklstemmer/index.mdx
@@ -2,7 +2,6 @@
 title: "Finding root words in a language no NLP library supports"
 description: "I built AklStemmer after discovering that dictionary-based spell checkers are difficult for inflected words."
 date: "2024-05-13"
-image: "./preview.png"
 ---
 
 Building [Aklish](/case-studies/aklish) uncovered a familiar problem.

--- a/src/content/case-studies/astra/index.mdx
+++ b/src/content/case-studies/astra/index.mdx
@@ -2,7 +2,6 @@
 title: "Catching code plagiarism without vector embeddings"
 description: "Code can look different while doing the same thing, so Astra compares program structure instead of text to detect similarities using traditional algorithms instead of machine learning."
 date: "2026-05"
-image: "./preview.jpg"
 ---
 
 import { Image } from "astro:assets";

--- a/src/content/case-studies/backlogs/index.mdx
+++ b/src/content/case-studies/backlogs/index.mdx
@@ -2,7 +2,6 @@
 title: "Turning a sentence into a task without an LLM"
 description: "Most task apps make you fill out separate fields for dates and priorities. Backlogs lets you type naturally and extracts them automatically with a rule-based parser."
 date: "2025-05-17"
-image: "./preview.gif"
 ---
 
 import { Image } from "astro:assets";

--- a/src/content/case-studies/ehalalan/index.mdx
+++ b/src/content/case-studies/ehalalan/index.mdx
@@ -2,7 +2,6 @@
 title: "Making an election result verifiable without a trusted middleman"
 description: "We built eHalalan to explore whether blockchain could make election results publicly verifiable without relying on a single authority to tally the votes."
 date: "2025-04-05"
-image: "./preview.gif"
 ---
 
 import { Image } from "astro:assets";

--- a/src/content/case-studies/iskommerce/index.mdx
+++ b/src/content/case-studies/iskommerce/index.mdx
@@ -2,7 +2,6 @@
 title: "Replacing students' #ForSale posts with an actual marketplace"
 description: "Students already buy and sell through scattered Facebook posts, so Iskommerce turns those into a structured marketplace while exploring whether more structure actually makes a better experience."
 date: "2026-05-26"
-image: "./preview.jpg"
 ---
 
 import { Image } from "astro:assets";

--- a/src/content/case-studies/manobela/index.mdx
+++ b/src/content/case-studies/manobela/index.mdx
@@ -2,7 +2,7 @@
 title: "Making driver safety monitoring accessible with just a phone camera"
 description: "Most driver monitoring systems require expensive hardware, so Manobela uses phones to detect drowsiness and distraction in real time."
 date: "2026-02-03"
-image: "./preview.jpg"
+image: "./mockups/mockup_monitoring_annotated.png"
 ---
 
 import { Image } from "astro:assets";

--- a/src/content/case-studies/miago/index.mdx
+++ b/src/content/case-studies/miago/index.mdx
@@ -2,7 +2,6 @@
 title: "Turning Messenger food orders into a real delivery system"
 description: "Miagao's food delivery runs through scattered Messenger conversations, so MiaGo turns informal orders into a structured system for customers, vendors, and riders."
 date: "2026-05-24"
-image: "./preview.jpg"
 ---
 
 import { Image } from "astro:assets";

--- a/src/content/case-studies/project-hermes/index.mdx
+++ b/src/content/case-studies/project-hermes/index.mdx
@@ -2,7 +2,6 @@
 title: "Integrating AI into critical systems without making it critical"
 description: "Project HERMES uses AI to turn natural disaster reports into structured incident data while keeping human validation and reliable workflows in control."
 date: "2026-04-25"
-image: "./preview.gif"
 ---
 
 import { Image } from "astro:assets";

--- a/src/content/case-studies/renux/index.mdx
+++ b/src/content/case-studies/renux/index.mdx
@@ -2,7 +2,6 @@
 title: "Building the TUI file renamer I wanted and discovering 5K people wanted it too"
 description: "I got tired of leaving the terminal just to rename files, so I built the tool I actually wanted to use. It turns out I wasn't the only one."
 date: "2025-06-22"
-image: "./demo.gif"
 ---
 
 import { Image } from "astro:assets";

--- a/src/content/case-studies/taglid/index.mdx
+++ b/src/content/case-studies/taglid/index.mdx
@@ -2,7 +2,6 @@
 title: "Telling Tagalog and English Apart Inside the Same Sentence"
 description: "I built TagLID after existing language detectors failed on Taglish during a research project."
 date: "2023-12-21"
-image: "./preview.png"
 ---
 
 Taglish is messy.

--- a/src/content/case-studies/tglstemmer/index.mdx
+++ b/src/content/case-studies/tglstemmer/index.mdx
@@ -2,7 +2,6 @@
 title: "Recovering root words from Tagalog's heavy affixing"
 description: "I built TglStemmer after discovering that dictionary lookups weren't enough for TagLID"
 date: "2023-12-27"
-image: "./preview.png"
 ---
 
 Building [TagLID](/case-studies/taglid) exposed a problem I didn't expect.

--- a/src/content/case-studies/tidal-island/index.mdx
+++ b/src/content/case-studies/tidal-island/index.mdx
@@ -2,7 +2,7 @@
 title: "Building a game from scratch to finally understand OOP"
 description: "I built a survival game from scratch in Java, using real game systems as a way to understand OOP principles beyond textbook examples."
 date: "2025-12-13"
-image: "./preview.gif"
+image: "./screenshots/debug-render.png"
 ---
 
 import { Image } from "astro:assets";

--- a/src/content/case-studies/uniglyphs/index.mdx
+++ b/src/content/case-studies/uniglyphs/index.mdx
@@ -2,7 +2,6 @@
 title: "Formatting text on sites that don't let you"
 description: "I got tired of opening sketchy Unicode text generators every time I wanted bold text on LinkedIn or Facebook, so I built a browser extension that brings it directly into the page."
 date: "2025-07-02"
-image: "./preview.gif"
 ---
 
 import { Image } from "astro:assets";

--- a/src/content/case-studies/zipzap/index.mdx
+++ b/src/content/case-studies/zipzap/index.mdx
@@ -2,7 +2,6 @@
 title: "Building a file compressor from scratch to test my data structures"
 description: "Huffman coding needs trees, heaps, and hash maps to work, making it a good test for implementing core data structures from scratch."
 date: "2025-12-20"
-image: "./preview.png"
 ---
 
 ZipZap is a CLI tool that compresses text files using <a href="https://en.wikipedia.org/wiki/Huffman_coding" target="_blank"> Huffman coding </a> . It was built as an experiment in implementing data structures and algorithms from scratch, including priority queues, binary trees, and hash maps.

--- a/src/pages/projects/[...id].astro
+++ b/src/pages/projects/[...id].astro
@@ -91,6 +91,17 @@ const { posts, caseStudies } = await resolveRelatedContent(
         ) : null
       }
     </div>
+    {
+      project.image && (
+        <div class="animate text-muted my-10 aspect-video overflow-hidden rounded-lg text-xs">
+          <img
+            src={project.image}
+            alt={project.title}
+            class="h-full w-full object-cover"
+          />
+        </div>
+      )
+    }
     <div class="animate">
       <RelatedContent posts={posts} caseStudies={caseStudies} />
     </div>


### PR DESCRIPTION
## Summary
- Case studies previously reused the same preview image as their corresponding project, so removing it from the project card duplicated content.
- Add the project's preview image directly to the project detail page, since it's no longer surfaced via the case study card.
- Remove the `image` frontmatter from most case studies, keeping only `event-photo-match` and replacing the preview for a couple others with a more process-oriented image.
- Case studies will get their own distinct "look into the process" preview images going forward instead of mirroring the project cover.

## Test plan
- [x] `astro check` passes with no errors
- [x] Verified project detail page renders the preview image above related content