### PR TITLE
fix(rss): include projects in RSS feed

### DIFF
--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -1,29 +1,36 @@
 import rss from "@astrojs/rss";
 import { SITE } from "@consts";
 import { getCollection } from "astro:content";
+import { projects } from "@data/projects";
 
 export async function GET(context) {
   const posts = (await getCollection("posts")).filter(
     (post) => !post.data.draft,
   );
 
-  const projects = (await getCollection("projects")).filter(
-    (project) => !project.data.draft,
-  );
+  const activeProjects = projects.filter((project) => !project.draft);
 
-  const items = [...posts, ...projects].sort(
-    (a, b) => new Date(b.data.date).valueOf() - new Date(a.data.date).valueOf(),
+  const items = [
+    ...posts.map((post) => ({
+      title: post.data.title,
+      description: post.data.description,
+      pubDate: post.data.date,
+      link: `/${post.collection}/${post.id}/`,
+    })),
+    ...activeProjects.map((project) => ({
+      title: project.title,
+      description: project.description,
+      pubDate: new Date(project.startDate),
+      link: `/projects/${project.id}/`,
+    })),
+  ].sort(
+    (a, b) => new Date(b.pubDate).valueOf() - new Date(a.pubDate).valueOf(),
   );
 
   return rss({
     title: SITE.TITLE,
     description: SITE.DESCRIPTION,
     site: context.site,
-    items: items.map((item) => ({
-      title: item.data.title,
-      description: item.data.description,
-      pubDate: item.data.date,
-      link: `/${item.collection}/${item.id}/`,
-    })),
+    items,
   });
 }


### PR DESCRIPTION
Closes #135

# Summary

`rss.xml.js` now imports `projects` directly, filters drafts, and normalizes posts + projects into a common shape before sorting into the feed.
