### PR TITLE
fix(config): register mermaid before mdx and enable MDX optimize

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,9 +16,6 @@ export default defineConfig({
   },
   integrations: [
     sitemap(),
-    mdx(),
-    pagefind(),
-    icon(),
     mermaid({
       theme: "dark",
       autoTheme: true,
@@ -28,6 +25,9 @@ export default defineConfig({
         securityLevel: "strict",
       },
     }),
+    mdx({ optimize: true }),
+    pagefind(),
+    icon(),
     partytown(),
   ],
   vite: {


### PR DESCRIPTION
Closes #139

## Summary

`astro-mermaid` was registered after `mdx()` in `integrations`, and MDX's Satteri-based compile pipeline discards raw HTML mdast nodes unless `optimize` is enabled, so mermaid fences in `.mdx` files rendered as HTML-escaped literal text instead of a live `<pre class="mermaid">` element.

## Notes

Reordering alone did not fix it. The actual fix is passing `optimize: true` to `mdx()`, which makes Astro's Satteri MDX compiler emit raw HTML (via `set:html`) instead of escaping it.