### PR TITLE
fix(head): correct copy-code button class assignment

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -287,7 +287,7 @@ const {
 
       const copyButton = document.createElement("button");
       copyButton.innerText = copyButtonLabel;
-      copyButton.classList = "copy-code";
+      copyButton.classList.add("copy-code");
 
       codeBlock.setAttribute("tabindex", "0");
       codeBlock.appendChild(copyButton);


### PR DESCRIPTION
Closes #141

## Summary

Fixes the copy-code button in `src/components/Head.astro` never getting its `.copy-code` class. It was being set with `copyButton.classList = "copy-code"`, which is a silent no-op since `classList` is read-only. Changed to `copyButton.classList.add("copy-code")`.
