### PR TITLE
fix(head): copy full code text without stripping first occurrence

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -302,9 +302,9 @@ const {
   }
 
   async function copyCode(codeBlock, copyButton) {
-    const codeText = codeBlock.innerText;
-    const buttonText = copyButton.innerText;
-    const textToCopy = codeText.replace(buttonText, "");
+    const clone = codeBlock.cloneNode(true);
+    clone.querySelector(".copy-code")?.remove();
+    const textToCopy = clone.textContent ?? "";
 
     await navigator.clipboard.writeText(textToCopy);
     copyButton.innerText = copiedButtonLabel;


### PR DESCRIPTION
Closes #142

## Summary

The copy-to-clipboard button stripped the button label from copied code using `codeText.replace(buttonText, "")`. Since string `.replace` only removes the first occurrence, code snippets containing the word "copy" earlier in their text (e.g. "deep copy", a comment) would have that occurrence removed instead of the actual button label, corrupting the copied content.

Fixed by cloning the code block, removing the button element from the clone, and reading `textContent` from the clone. This avoids string surgery entirely and always copies the exact code content regardless of what words appear in it.
