### PR TITLE
fix(seo): add is:inline to StructuredData script tag

### DIFF
--- a/src/components/StructuredData.astro
+++ b/src/components/StructuredData.astro
@@ -12,6 +12,7 @@ const { data } = Astro.props;
 ---
 
 <script
+  is:inline
   type="application/ld+json"
   set:html={JSON.stringify(data).replace(/</g, "\\u003c")}
 />


### PR DESCRIPTION
Closes #149

## Summary

Adds the `is:inline` directive to the JSON-LD script tag in StructuredData.astro. The script was already being treated as inline because it has an attribute, but without the explicit directive, `astro check` (run in `npm run build`) emitted an astro(4000) hint.
