### PR TITLE
fix(github-contributions): warn on build-time fetch failure

### DIFF
--- a/src/components/GithubContributions.astro
+++ b/src/components/GithubContributions.astro
@@ -39,23 +39,31 @@ if (token) {
     }
   `;
 
-  const res = await fetch("https://api.github.com/graphql", {
-    method: "POST",
-    headers: {
-      Authorization: `bearer ${token}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ query, variables: { username } }),
-  });
+  try {
+    const res = await fetch("https://api.github.com/graphql", {
+      method: "POST",
+      headers: {
+        Authorization: `bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ query, variables: { username } }),
+    });
 
-  if (res.ok) {
-    const json = await res.json();
-    const calendar =
-      json?.data?.user?.contributionsCollection?.contributionCalendar;
-    if (calendar) {
-      weeks = calendar.weeks;
-      totalContributions = calendar.totalContributions;
+    if (res.ok) {
+      const json = await res.json();
+      const calendar =
+        json?.data?.user?.contributionsCollection?.contributionCalendar;
+      if (calendar) {
+        weeks = calendar.weeks;
+        totalContributions = calendar.totalContributions;
+      }
+    } else {
+      console.warn(
+        `GithubContributions: fetch failed with status ${res.status} ${res.statusText}`,
+      );
     }
+  } catch (err) {
+    console.warn("GithubContributions: fetch failed", err);
   }
 }
 


### PR DESCRIPTION
Closes #148

## Summary

`GithubContributions.astro` fetches GitHub's GraphQL API at build time but silently rendered empty on fetch failure or a non-ok response, with nothing logged to tell you why. Wrapped the fetch in a try/catch and added `console.warn` on both failure paths (network error and non-ok response) so build logs surface the problem. Still degrades gracefully, no build errors thrown.
